### PR TITLE
Linux fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,13 +8,14 @@ pub const HostApi = enum {
     dsound,
     jack,
     oss,
+    pulseaudio,
     wasapi,
     wdmks,
     wmme,
 
     pub const defaults = struct {
         pub const macos: []const HostApi = &.{.coreaudio};
-        pub const linux: []const HostApi = &.{.alsa};
+        pub const linux: []const HostApi = &.{ .alsa, .pulseaudio };
         pub const windows: []const HostApi = &.{.wasapi};
     };
 };
@@ -110,6 +111,12 @@ pub fn build(b: *std.Build) !void {
                         try flags.append("-DPA_USE_OSS=1");
                         lib.addIncludePath(pa.path("src/hostapi/oss"));
                         lib.addCSourceFiles(.{ .root = pa_root, .files = src_hostapi_oss });
+                    },
+                    .pulseaudio => {
+                        try flags.append("-DPA_USE_PULSEAUDIO=1");
+                        lib.addIncludePath(pa.path("src/hostapi/pulseaudio"));
+                        lib.addCSourceFiles(.{ .root = pa_root, .files = src_hostapi_pulseaudio });
+                        lib.linkSystemLibrary("pulse");
                     },
                     else => unsupportedHostApi(t.os.tag, api),
                 }
@@ -219,6 +226,12 @@ const src_hostapi_jack = &.{
 
 const src_hostapi_oss = &.{
     "src/hostapi/oss/pa_unix_oss.c",
+};
+
+const src_hostapi_pulseaudio = &.{
+    "src/hostapi/pulseaudio/pa_linux_pulseaudio.c",
+    "src/hostapi/pulseaudio/pa_linux_pulseaudio_block.c",
+    "src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c",
 };
 
 const src_hostapi_wasapi = &.{

--- a/build.zig
+++ b/build.zig
@@ -93,7 +93,7 @@ pub fn build(b: *std.Build) !void {
                         try flags.append("-DPA_USE_ALSA=1");
                         lib.addIncludePath(pa.path("src/hostapi/alsa"));
                         lib.addCSourceFiles(.{ .root = pa_root, .files = src_hostapi_alsa });
-                        lib.linkSystemLibrary("alsa");
+                        lib.linkSystemLibrary("asound");
                     },
                     .asihpi => {
                         try flags.append("-DPA_USE_ASIHPI=1");
@@ -105,7 +105,7 @@ pub fn build(b: *std.Build) !void {
                         try flags.append("-DPA_USE_JACK=1");
                         lib.addIncludePath(pa.path("src/hostapi/jack"));
                         lib.addCSourceFiles(.{ .root = pa_root, .files = src_hostapi_jack });
-                        lib.linkSystemLibrary("jack2");
+                        lib.linkSystemLibrary("jack");
                     },
                     .oss => {
                         try flags.append("-DPA_USE_OSS=1");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
         .portaudio = .{
-            .url = "https://github.com/PortAudio/portaudio/archive/57aa393109ec996799d3a5846c9ecb0a65b64644.tar.gz",
-            .hash = "1220b589392688b377559ee6b0d26936bf8cd529821925ff4d8fb5f2b4923779cb66",
+            .url = "git+https://github.com/PortAudio/portaudio.git?ref=master#57aa393109ec996799d3a5846c9ecb0a65b64644",
+            .hash = "12204186a16ba21dd8fc671754ef4e327ec3db7cbe5761a6c9f559fab69926f70add",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,11 @@
 .{
     .name = "portaudio",
-    .version = "19.7.0",
+    .version = "19.7.0-1",
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
         .portaudio = .{
-            .url = "https://github.com/PortAudio/portaudio/archive/refs/tags/v19.7.0.tar.gz",
-            .hash = "1220a96e42d87ae966106483e3351919c95b7c8129942c355fd173b38b2e7a0ae0a0",
+            .url = "https://github.com/PortAudio/portaudio/archive/57aa393109ec996799d3a5846c9ecb0a65b64644.tar.gz",
+            .hash = "1220b589392688b377559ee6b0d26936bf8cd529821925ff4d8fb5f2b4923779cb66",
         },
     },
     .paths = .{


### PR DESCRIPTION
- Add Pulseaudio backend
- Make Pulseaudio + ALSA the default backends on Linux
- Update upstream to master, because the latest tag is from several years ago and does not include Pulseaudio
- Fix system library names for ALSA and JACK